### PR TITLE
fix: Use utf-8 encoding when saving config.toml file

### DIFF
--- a/code/utils/config.py
+++ b/code/utils/config.py
@@ -22,21 +22,21 @@ config = toml.load("./utils/config.toml")
 
 
 def saveOnClose(data, config="utils/config.toml"):
-    with open(config, 'w') as fh:
+    with open(config, 'w', encoding='utf-8') as fh:
         toml.dump(data, fh)
 
 
 def editConfig(index, replacementText, config="utils/config.toml"):
     data = toml.load(config)
     data[index] = replacementText
-    with open(config, 'w') as fh:
+    with open(config, 'w', encoding='utf-8') as fh:
         toml.dump(data, fh)
 
 
 def editSelectionConfig(index, cBoxName, config="utils/config.toml"):
     data = toml.load(config)
     data["SELECTED_INDEX"][cBoxName] = index
-    with open(config, 'w') as fh:
+    with open(config, 'w', encoding='utf-8') as fh:
         toml.dump(data, fh)
 
 


### PR DESCRIPTION
Closes #28 

When opening a directory with Japanese characters and closing the app, the `config.toml` file was being saved with shift-jis encoding instead of utf-8, causing the program to crash when it tries to reread the config file.